### PR TITLE
doc: fix small bug/typo in circle-ci config file and readme

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,4 +21,4 @@ jobs:
       - store_test_results:
           path: target/surefire-reports
       - store_artifacts:
-path: target/ftpclient-0.0.1-SNAPSHOT.jar
+          path: target/ftpclient-0.0.1-SNAPSHOT.jar

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # FTP Client
-[![Build Status](https://travis-ci.com/psu-agile-group/FTP-Client-Maven.svg?branch=master)](https://travis-ci.com/psu-agile-group/FTP-Client-Maven)
-[![CircleCI Status](https://circleci.com/gh/psu-agile-group/FTP-Client-Maven.svg?style=shield&circle-token=:circle-token)](https://circleci.com/gh/psu-agile-group/FTP-Client-Maven)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/psu-agile-group/FTP-Client-Maven/License)
-[![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/dwyl/esta/issues)
+[![Build Status](https://travis-ci.com/psu-agile-group/FTP-Client.svg?branch=master)](https://travis-ci.com/psu-agile-group/FTP-Client)
+[![CircleCI Status](https://circleci.com/gh/psu-agile-group/FTP-Client.svg?style=shield&circle-token=:circle-token)](https://circleci.com/gh/psu-agile-group/FTP-Client)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/psu-agile-group/FTP-Client/License)
+[![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/psu-agile-group/FTP-Client/issues)
 
 A FTP (or File Transfer Protocol) client that is used for the transfer of computer files between a client and server on network by using JAVA and Apache Commons Net™ library.
 <!--project description-->
@@ -21,11 +21,17 @@ A FTP (or File Transfer Protocol) client that is used for the transfer of comput
 * [Repository](https://github.com/psu-agile-group)
 * [Backlog](https://github.com/psu-agile-group/psu-agile-group.github.io/blob/master/BACKLOG.md)
 
-## Tech stack, Pre-reqs and Setup
-//TODO
+## Tech stack, Tools, Prerequisites and Setup
+- [x] Java
+- [x] Apache Commons Net™ library
+- [x] IntelliJ
+- [x] Apache Maven
+- [x] Git
+- [x] Travis-CI
+- [x] Circle-CI
 
-## Build
-//TODO
+#### &nbsp;&nbsp;Build
+&nbsp;&nbsp;[Wiki Page](https://github.com/psu-agile-group/FTP-Client/wiki/Setup)
 
-## Run
-//TODO
+#### &nbsp;&nbsp;Run
+&nbsp;&nbsp;[Wiki Page](https://github.com/psu-agile-group/FTP-Client/wiki/Run)


### PR DESCRIPTION
This is related to the recent PR #50. 

Fixes:
- [x] Incorrect line spacing in Circle-CI config file that cause automated testing to failed: [![CircleCI Status](https://circleci.com/gh/psu-agile-group/FTP-Client.svg?style=shield&circle-token=:circle-token)](https://circleci.com/gh/psu-agile-group/FTP-Client)
- [x] typo and Incorrect Github repo in README

Add:
- [x] Wiki page is WIP: [here](https://github.com/psu-agile-group/FTP-Client/wiki)